### PR TITLE
BrysonH98 - Adding smtp read and write scopes to OIDCClient token call

### DIFF
--- a/rs/utils/clients.py
+++ b/rs/utils/clients.py
@@ -172,7 +172,9 @@ class UMAClient:
                 https://gluu.org/auth/oxtrust.saml.read \
                 https://gluu.org/auth/oxtrust.saml.write \
                 https://gluu.org/auth/oxtrust.scope.read \
-                https://gluu.org/auth/oxtrust.scope.write'
+                https://gluu.org/auth/oxtrust.scope.write \
+                https://gluu.org/auth/oxtrust.smtpconfiguration.read \
+                https://gluu.org/auth/oxtrust.smtpconfiguration.write'
             }
         return OIDCClient(idp_url, self.logger, self.verify).request_to_token_endpoint(self.b64_client_credentials, payload)['access_token']
 


### PR DESCRIPTION
I noticed when testing the deployment of GLUU that the SMTP configuration scopes weren't present in the auth call and therefore attempting to update the configuration via the oxTrust API would fail. In this fix I've added these scopes to the list of scopes